### PR TITLE
Use modern homebridge dependency spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "keywords": [
     "homebridge-plugin"
   ],
-  "peerDepdendencies": {
+  "engines": {
     "homebridge": ">=0.4.27"
   },
   "dependencies": {


### PR DESCRIPTION
As of nfarina/homebridge#2411, homebridge fails to load homebridge-milight:
```
Error: Plugin /homebridge/node_modules/homebridge-milight does not contain the 'homebridge' package in 'engines'.
    at Plugin.load (/usr/local/lib/node_modules/homebridge/lib/plugin.js:49:11)
    at Server.<anonymous> (/usr/local/lib/node_modules/homebridge/lib/server.js:153:14)
    at Array.forEach (<anonymous>)
    at Server._loadPlugins (/usr/local/lib/node_modules/homebridge/lib/server.js:145:22)
    at new Server (/usr/local/lib/node_modules/homebridge/lib/server.js:57:24)
    at module.exports (/usr/local/lib/node_modules/homebridge/lib/cli.js:32:16)
    at Object.<anonymous> (/usr/local/lib/node_modules/homebridge/bin/homebridge:17:22)
    at Module._compile (internal/modules/cjs/loader.js:1158:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
    at Module.load (internal/modules/cjs/loader.js:1002:32)
```

This adopts the preferred homebridge dependency spec, which is unaffected. 